### PR TITLE
Fix the GetIdentity request to use the txproofheight when converting from JSON.

### DIFF
--- a/dist/api/classes/GetIdentity/GetIdentityRequest.js
+++ b/dist/api/classes/GetIdentity/GetIdentityRequest.js
@@ -21,7 +21,7 @@ class GetIdentityRequest extends ApiRequest_1.ApiRequest {
         return params.filter((x) => x != null);
     }
     static fromJson(object) {
-        return new GetIdentityRequest(object.chain, object.nameOrAddress, object.height != null ? object.height : undefined, object.txproof != null ? object.txproof : undefined, object.txproofheight != null ? object.txproof : undefined);
+        return new GetIdentityRequest(object.chain, object.nameOrAddress, object.height != null ? object.height : undefined, object.txproof != null ? object.txproof : undefined, object.txproofheight != null ? object.txproofheight : undefined);
     }
     toJson() {
         return {

--- a/src/api/classes/GetIdentity/GetIdentityRequest.ts
+++ b/src/api/classes/GetIdentity/GetIdentityRequest.ts
@@ -39,7 +39,7 @@ export class GetIdentityRequest extends ApiRequest {
       object.nameOrAddress as string,
       object.height != null ? (object.height as number) : undefined,
       object.txproof != null ? (object.txproof as boolean) : undefined,
-      object.txproofheight != null ? (object.txproof as number) : undefined
+      object.txproofheight != null ? (object.txproofheight as number) : undefined
     );
   }
 


### PR DESCRIPTION
Currently the GetIdentity request assigns the `txproof` value of the JSON object to the `txproofheight` value when converting. This PR changes it to use the `txproofheight` value instead.