### PR TITLE
Add a Serializable Credential Class

### DIFF
--- a/dist/pbaas/Credential.d.ts
+++ b/dist/pbaas/Credential.d.ts
@@ -1,0 +1,53 @@
+/// <reference types="bn.js" />
+/// <reference types="node" />
+import { BigNumber } from "../utils/types/BigNumber";
+import { SerializableEntity } from "../utils/types/SerializableEntity";
+export declare type CredentialJSON = {
+    version?: number;
+    flags?: number;
+    credentialType?: number;
+    credential?: string;
+    recipient?: string;
+    note?: string;
+};
+export declare class Credential implements SerializableEntity {
+    static VERSION_INVALID: import("bn.js");
+    static VERSION_FIRST: import("bn.js");
+    static VERSION_LAST: import("bn.js");
+    static VERSION_CURRENT: import("bn.js");
+    static FLAG_NOTE_PRESENT: import("bn.js");
+    static CREDENTIAL_UNKNOWN: import("bn.js");
+    static CREDENTIAL_USERNAME: import("bn.js");
+    static CREDENTIAL_PASSWORD: import("bn.js");
+    static CREDENTIAL_CARD_NUMBER: import("bn.js");
+    static CREDENTIAL_CARD_EXPIRATION_MONTH: import("bn.js");
+    static CREDENTIAL_CARD_EXPIRATION_YEAR: import("bn.js");
+    static CREDENTIAL_CARD_SECURITY_CODE: import("bn.js");
+    static CREDENTIAL_ADDRESS: import("bn.js");
+    static CREDENTIAL_AREA_CODE: import("bn.js");
+    static CREDENTIAL_DATE_OF_BIRTH: import("bn.js");
+    static CREDENTIAL_ID: import("bn.js");
+    version: BigNumber;
+    flags: BigNumber;
+    credentialType: BigNumber;
+    credential: string;
+    recipient: string;
+    note: string;
+    constructor(data?: {
+        version?: BigNumber;
+        flags?: BigNumber;
+        credentialType?: BigNumber;
+        credential?: string;
+        recipient?: string;
+        note?: string;
+    });
+    getByteLength(): number;
+    toBuffer(): Buffer;
+    fromBuffer(buffer: Buffer, offset?: number): number;
+    hasNote(): boolean;
+    calcFlags(): BigNumber;
+    setFlags(): void;
+    isValid(): boolean;
+    toJSON(): CredentialJSON;
+    static fromJSON(json: CredentialJSON): Credential;
+}

--- a/dist/pbaas/Credential.d.ts
+++ b/dist/pbaas/Credential.d.ts
@@ -27,6 +27,7 @@ export declare class Credential implements SerializableEntity {
     static CREDENTIAL_AREA_CODE: import("bn.js");
     static CREDENTIAL_DATE_OF_BIRTH: import("bn.js");
     static CREDENTIAL_ID: import("bn.js");
+    static CREDENTIAL_PHONE_NUMBER: import("bn.js");
     version: BigNumber;
     flags: BigNumber;
     credentialType: BigNumber;

--- a/dist/pbaas/Credential.js
+++ b/dist/pbaas/Credential.js
@@ -1,0 +1,125 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Credential = void 0;
+const bn_js_1 = require("bn.js");
+const bufferutils_1 = require("../utils/bufferutils");
+const varuint_1 = require("../utils/varuint");
+const { BufferReader, BufferWriter } = bufferutils_1.default;
+class Credential {
+    constructor(data) {
+        this.version = Credential.VERSION_INVALID;
+        this.flags = new bn_js_1.BN(0, 10);
+        this.credentialType = Credential.CREDENTIAL_UNKNOWN;
+        this.credential = "";
+        this.recipient = "";
+        this.note = "";
+        if (data) {
+            if (data.flags)
+                this.flags = data.flags;
+            if (data.version)
+                this.version = data.version;
+            if (data.credentialType)
+                this.credentialType = data.credentialType;
+            if (data.credential)
+                this.credential = data.credential;
+            if (data.recipient)
+                this.recipient = data.recipient;
+            if (data.note)
+                this.note = data.note;
+            this.setFlags();
+        }
+    }
+    getByteLength() {
+        let length = 0;
+        length += 4; // version (UInt32)
+        length += 4; // flags (UInt32)
+        length += 4; // credentialType (UInt32)
+        const credentialLength = this.credential.length;
+        length += varuint_1.default.encodingLength(credentialLength);
+        length += credentialLength;
+        const recipientLength = this.recipient.length;
+        length += varuint_1.default.encodingLength(recipientLength);
+        length += recipientLength;
+        if (this.hasNote()) {
+            length += varuint_1.default.encodingLength(this.note.length);
+            length += Buffer.from(this.note).length;
+        }
+        return length;
+    }
+    toBuffer() {
+        const writer = new BufferWriter(Buffer.alloc(this.getByteLength()));
+        writer.writeUInt32(this.version.toNumber());
+        writer.writeUInt32(this.flags.toNumber());
+        writer.writeUInt32(this.credentialType.toNumber());
+        writer.writeVarSlice(Buffer.from(this.credential));
+        writer.writeVarSlice(Buffer.from(this.recipient));
+        if (this.hasNote()) {
+            writer.writeVarSlice(Buffer.from(this.note));
+        }
+        return writer.buffer;
+    }
+    fromBuffer(buffer, offset) {
+        const reader = new BufferReader(buffer, offset);
+        this.version = new bn_js_1.BN(reader.readUInt32(), 10);
+        this.flags = new bn_js_1.BN(reader.readUInt32(), 10);
+        this.credentialType = new bn_js_1.BN(reader.readUInt32(), 10);
+        this.credential = Buffer.from(reader.readVarSlice()).toString();
+        this.recipient = Buffer.from(reader.readVarSlice()).toString();
+        if (this.hasNote()) {
+            this.note = Buffer.from(reader.readVarSlice()).toString();
+        }
+        return reader.offset;
+    }
+    hasNote() {
+        return this.flags.and(Credential.FLAG_NOTE_PRESENT).gt(new bn_js_1.BN(0, 10));
+    }
+    calcFlags() {
+        return this.note.length > 0 ? Credential.FLAG_NOTE_PRESENT : new bn_js_1.BN(0, 10);
+    }
+    setFlags() {
+        this.flags = this.calcFlags();
+    }
+    isValid() {
+        return this.version.gte(Credential.VERSION_FIRST) && this.version.lte(Credential.VERSION_LAST);
+    }
+    toJSON() {
+        const ret = {
+            version: this.version.toNumber(),
+            flags: this.flags.toNumber(),
+            credentialType: this.credentialType.toNumber(),
+            credential: this.credential,
+            recipient: this.recipient,
+            note: this.hasNote() ? this.note : null
+        };
+        return ret;
+    }
+    static fromJSON(json) {
+        return new Credential({
+            version: json.version ? new bn_js_1.BN(json.version, 10) : undefined,
+            flags: json.flags ? new bn_js_1.BN(json.flags, 10) : undefined,
+            credentialType: json.credentialType ? new bn_js_1.BN(json.credentialType, 10) : undefined,
+            credential: json.credential,
+            recipient: json.recipient,
+            note: json.note,
+        });
+    }
+}
+exports.Credential = Credential;
+// Credential enum types 
+Credential.VERSION_INVALID = new bn_js_1.BN(0, 10);
+Credential.VERSION_FIRST = new bn_js_1.BN(1, 10);
+Credential.VERSION_LAST = new bn_js_1.BN(1, 10);
+Credential.VERSION_CURRENT = new bn_js_1.BN(1, 10);
+Credential.FLAG_NOTE_PRESENT = new bn_js_1.BN(1, 10);
+// Credential type definitions
+Credential.CREDENTIAL_UNKNOWN = new bn_js_1.BN(0, 10); // unknown credential
+Credential.CREDENTIAL_USERNAME = new bn_js_1.BN(1, 10);
+Credential.CREDENTIAL_PASSWORD = new bn_js_1.BN(2, 10);
+Credential.CREDENTIAL_CARD_NUMBER = new bn_js_1.BN(3, 10); // payment credentials
+Credential.CREDENTIAL_CARD_EXPIRATION_MONTH = new bn_js_1.BN(4, 10);
+Credential.CREDENTIAL_CARD_EXPIRATION_YEAR = new bn_js_1.BN(5, 10);
+Credential.CREDENTIAL_CARD_SECURITY_CODE = new bn_js_1.BN(6, 10);
+Credential.CREDENTIAL_ADDRESS = new bn_js_1.BN(7, 10);
+Credential.CREDENTIAL_AREA_CODE = new bn_js_1.BN(8, 10);
+Credential.CREDENTIAL_DATE_OF_BIRTH = new bn_js_1.BN(9, 10);
+Credential.CREDENTIAL_ID = new bn_js_1.BN(10, 10);

--- a/dist/pbaas/Credential.js
+++ b/dist/pbaas/Credential.js
@@ -123,3 +123,4 @@ Credential.CREDENTIAL_ADDRESS = new bn_js_1.BN(7, 10);
 Credential.CREDENTIAL_AREA_CODE = new bn_js_1.BN(8, 10);
 Credential.CREDENTIAL_DATE_OF_BIRTH = new bn_js_1.BN(9, 10);
 Credential.CREDENTIAL_ID = new bn_js_1.BN(10, 10);
+Credential.CREDENTIAL_PHONE_NUMBER = new bn_js_1.BN(11, 10);

--- a/dist/vdxf/classes/Decision.d.ts
+++ b/dist/vdxf/classes/Decision.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import { VDXFObject } from "..";
+import { Credential } from "../../pbaas/Credential";
 import { Attestation } from "./Challenge";
 import { Context } from "./Context";
 import { Request, RequestInterface } from "./Request";
@@ -11,6 +12,7 @@ export interface DecisionInterface {
     skipped?: boolean;
     context?: Context;
     attestations?: Array<Attestation>;
+    credentials?: Array<Credential>;
 }
 export declare class Decision extends VDXFObject {
     decision_id: string;
@@ -20,6 +22,7 @@ export declare class Decision extends VDXFObject {
     skipped?: boolean;
     attestations: Array<any>;
     salt?: string;
+    credentials: Array<Credential>;
     constructor(decision?: DecisionInterface, vdxfkey?: string);
     dataByteLength(): number;
     toDataBuffer(): Buffer;

--- a/src/__tests__/pbaas/credential.test.ts
+++ b/src/__tests__/pbaas/credential.test.ts
@@ -14,9 +14,11 @@ describe('Serializes and deserializes Credential', () => {
 
     expect(cFromBuf.toBuffer().toString('hex')).toBe(c.toBuffer().toString('hex'));
     expect(cFromBuf.isValid());
+    expect(!cFromBuf.hasNote());
+    expect(cFromBuf.calcFlags() !== Credential.FLAG_NOTE_PRESENT);
   });
 
-  test('(de)serialize Credential without note', () => {
+  test('(de)serialize Credential with note', () => {
     const c = new Credential({
       version: Credential.VERSION_CURRENT,
       credentialType: Credential.CREDENTIAL_DATE_OF_BIRTH,
@@ -30,5 +32,7 @@ describe('Serializes and deserializes Credential', () => {
 
     expect(cFromBuf.toBuffer().toString('hex')).toBe(c.toBuffer().toString('hex'));
     expect(cFromBuf.isValid());
+    expect(cFromBuf.hasNote());
+    expect(cFromBuf.calcFlags() === Credential.FLAG_NOTE_PRESENT);
   });
 });

--- a/src/__tests__/pbaas/credential.test.ts
+++ b/src/__tests__/pbaas/credential.test.ts
@@ -1,0 +1,34 @@
+import { Credential } from "../../pbaas/Credential";
+
+describe('Serializes and deserializes Credential', () => {
+  test('(de)serialize Credential without note', () => {
+    const c = new Credential({
+      version: Credential.VERSION_CURRENT,
+      credentialType: Credential.CREDENTIAL_CARD_SECURITY_CODE,
+      credential: "481",
+      recipient: "CardUsingApplication@",
+    });
+
+    const cFromBuf = new Credential();
+    cFromBuf.fromBuffer(c.toBuffer());
+
+    expect(cFromBuf.toBuffer().toString('hex')).toBe(c.toBuffer().toString('hex'));
+    expect(cFromBuf.isValid());
+  });
+
+  test('(de)serialize Credential without note', () => {
+    const c = new Credential({
+      version: Credential.VERSION_CURRENT,
+      credentialType: Credential.CREDENTIAL_DATE_OF_BIRTH,
+      credential: "2025-03-14",
+      recipient: "DeliveryService@",
+      note: "YY-MM-DD",
+    });
+
+    const cFromBuf = new Credential();
+    cFromBuf.fromBuffer(c.toBuffer());
+
+    expect(cFromBuf.toBuffer().toString('hex')).toBe(c.toBuffer().toString('hex'));
+    expect(cFromBuf.isValid());
+  });
+});

--- a/src/__tests__/vdxf/loginconsent.test.ts
+++ b/src/__tests__/vdxf/loginconsent.test.ts
@@ -6,6 +6,7 @@ import { Context } from "../../vdxf/classes/Context";
 import { ProvisioningRequest } from "../../vdxf/classes/provisioning/ProvisioningRequest";
 import { ProvisioningResponse } from "../../vdxf/classes/provisioning/ProvisioningResponse";
 import { ProvisioningResult, ProvisioningTxid } from "../../vdxf/classes/provisioning/ProvisioningResult";
+import { Credential } from "../../pbaas/Credential";
 
 describe('Serializes and deserializes signature objects properly', () => {
   test('loginconsentrequest/response', async () => {
@@ -218,5 +219,204 @@ describe('Serializes and deserializes signature objects properly', () => {
 
     expect(_res.getDecisionHash(10000).toString('hex')).toBe(res.getDecisionHash(10000).toString('hex'))
     expect(_req.getChallengeHash().toString('hex')).toBe(req.getChallengeHash().toString('hex'))
+  });
+
+  test('loginconsentresponse with a credential', async () => {
+    const req = new LoginConsentRequest({
+      system_id: "i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV",
+      signing_id: "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+      signature: {
+        signature:
+          "AYG2IQABQSAN1fp6A9NIVbxvKuOVLLU+0I+G3oQGbRtS6u4Eampfb217Cdf5FCMScQhV9kMxtjI9GWzpchmjuiTB2tctk6qT",
+      },
+      challenge: {
+        challenge_id: "iKNufKJdLX3Xg8qFru9AuLBvivAEJ88PW4",
+        requested_access: [new RequestedPermission(IDENTITY_VIEW.vdxfid)],
+        subject: [
+          new Subject(
+            "fully.qualified.name",
+            ID_FULLYQUALIFIEDNAME_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_ADDRESS_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_SYSTEMID_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_PARENT_VDXF_KEY.vdxfid
+          ),
+        ],
+        provisioning_info: [
+          new ProvisioningInfo(
+            "https://127.0.0.1/",
+            LOGIN_CONSENT_ID_PROVISIONING_WEBHOOK_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_ADDRESS_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_SYSTEMID_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_PARENT_VDXF_KEY.vdxfid
+          ),
+        ],
+        session_id: "iRQZGW36o3RcVR1xyVT1qWdAKdxp3wUyrh",
+        redirect_uris: [
+          new RedirectUri(
+            "https://www.verus.io",
+            LOGIN_CONSENT_REDIRECT_VDXF_KEY.vdxfid
+          ),
+        ],
+        created_at: 1664382484,
+        salt: "i6NawEzHMocZnU4h8pPkGpHApvsrHjxwXE",
+        context: new Context({
+          ["i4KyLCxWZXeSkw15dF95CUKytEK3HU7em9"]: "test",
+        }),
+      },
+    });
+
+    const res = new LoginConsentResponse({
+      system_id: "i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV",
+      signing_id: "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+      signature: {
+        signature:
+          "AYG2IQABQSAN1fp6A9NIVbxvKuOVLLU+0I+G3oQGbRtS6u4Eampfb217Cdf5FCMScQhV9kMxtjI9GWzpchmjuiTB2tctk6qT",
+      },
+      decision: {
+        decision_id: "iBTMBHzDbsW3QG1MLBoYtmo6c1xuzn6xxb",
+        context: new Context({
+          ["i4KyLCxWZXeSkw15dF95CUKytEK3HU7em9"]: "test",
+        }),
+        request: req,
+        created_at: 1664392484,
+        credentials: [
+          new Credential({
+            version: Credential.VERSION_CURRENT,
+            credentialType: Credential.CREDENTIAL_CARD_NUMBER,
+            credential: "1234567891011121",
+            recipient: "PizzaPlace@",
+          })
+        ]
+      }
+    })
+    const resbuf = res.toBuffer()
+    const _res = new LoginConsentResponse()
+    _res.fromBuffer(resbuf)
+
+    expect(_res.toBuffer().toString('hex')).toBe(resbuf.toString('hex'));
+
+    expect(_res.getDecisionHash(10000, 1).toString('hex')).toBe(res.getDecisionHash(10000, 1).toString('hex'))
+    expect(_res.getDecisionHash(10000, 2).toString('hex')).toBe(res.getDecisionHash(10000, 2).toString('hex'))
+  });
+
+  test('loginconsentresponse with credentials', async () => {
+    const req = new LoginConsentRequest({
+      system_id: "i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV",
+      signing_id: "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+      signature: {
+        signature:
+          "AYG2IQABQSAN1fp6A9NIVbxvKuOVLLU+0I+G3oQGbRtS6u4Eampfb217Cdf5FCMScQhV9kMxtjI9GWzpchmjuiTB2tctk6qT",
+      },
+      challenge: {
+        challenge_id: "iKNufKJdLX3Xg8qFru9AuLBvivAEJ88PW4",
+        requested_access: [new RequestedPermission(IDENTITY_VIEW.vdxfid)],
+        subject: [
+          new Subject(
+            "fully.qualified.name",
+            ID_FULLYQUALIFIEDNAME_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_ADDRESS_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_SYSTEMID_VDXF_KEY.vdxfid
+          ),
+          new Subject(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_PARENT_VDXF_KEY.vdxfid
+          ),
+        ],
+        provisioning_info: [
+          new ProvisioningInfo(
+            "https://127.0.0.1/",
+            LOGIN_CONSENT_ID_PROVISIONING_WEBHOOK_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_ADDRESS_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_SYSTEMID_VDXF_KEY.vdxfid
+          ),
+          new ProvisioningInfo(
+            "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+            ID_PARENT_VDXF_KEY.vdxfid
+          ),
+        ],
+        session_id: "iRQZGW36o3RcVR1xyVT1qWdAKdxp3wUyrh",
+        redirect_uris: [
+          new RedirectUri(
+            "https://www.verus.io",
+            LOGIN_CONSENT_REDIRECT_VDXF_KEY.vdxfid
+          ),
+        ],
+        created_at: 1664382484,
+        salt: "i6NawEzHMocZnU4h8pPkGpHApvsrHjxwXE",
+        context: new Context({
+          ["i4KyLCxWZXeSkw15dF95CUKytEK3HU7em9"]: "test",
+        }),
+      },
+    });
+
+    const res = new LoginConsentResponse({
+      system_id: "i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV",
+      signing_id: "iB5PRXMHLYcNtM8dfLB6KwfJrHU2mKDYuU",
+      signature: {
+        signature:
+          "AYG2IQABQSAN1fp6A9NIVbxvKuOVLLU+0I+G3oQGbRtS6u4Eampfb217Cdf5FCMScQhV9kMxtjI9GWzpchmjuiTB2tctk6qT",
+      },
+      decision: {
+        decision_id: "iBTMBHzDbsW3QG1MLBoYtmo6c1xuzn6xxb",
+        context: new Context({
+          ["i4KyLCxWZXeSkw15dF95CUKytEK3HU7em9"]: "test",
+        }),
+        request: req,
+        created_at: 1664392484,
+        credentials: [
+          new Credential({
+            version: Credential.VERSION_CURRENT,
+            credentialType: Credential.CREDENTIAL_PHONE_NUMBER,
+            credential: "1234567890",
+            recipient: "PizzaPlace@",
+          }),
+          new Credential({
+            version: Credential.VERSION_CURRENT,
+            credentialType: Credential.CREDENTIAL_CARD_NUMBER,
+            credential: "1234567891011121",
+            recipient: "PizzaPlace@",
+            note: "mastercard",
+          })
+        ]
+      }
+    })
+    const resbuf = res.toBuffer()
+    const _res = new LoginConsentResponse()
+    _res.fromBuffer(resbuf)
+
+    expect(_res.toBuffer().toString('hex')).toBe(resbuf.toString('hex'));
+
+    expect(_res.getDecisionHash(10000, 1).toString('hex')).toBe(res.getDecisionHash(10000, 1).toString('hex'))
+    expect(_res.getDecisionHash(10000, 2).toString('hex')).toBe(res.getDecisionHash(10000, 2).toString('hex'))
   });
 });

--- a/src/pbaas/Credential.ts
+++ b/src/pbaas/Credential.ts
@@ -1,0 +1,171 @@
+import { BigNumber } from "../utils/types/BigNumber";
+import { BN } from 'bn.js';
+import bufferutils from "../utils/bufferutils";
+import { SerializableEntity } from "../utils/types/SerializableEntity";
+import varuint from "../utils/varuint";
+
+const { BufferReader, BufferWriter } = bufferutils;
+
+export type CredentialJSON = {
+  version?: number,
+  flags?: number,
+  credentialType?: number,
+  credential?: string,
+  recipient?: string,
+  note?: string,
+}
+
+export class Credential implements SerializableEntity {
+
+  // Credential enum types 
+  static VERSION_INVALID = new BN(0, 10);
+  static VERSION_FIRST = new BN(1, 10);
+  static VERSION_LAST = new BN(1, 10);
+  static VERSION_CURRENT = new BN(1, 10);
+
+  static FLAG_NOTE_PRESENT = new BN(1, 10);
+
+  // Credential type definitions
+  static CREDENTIAL_UNKNOWN = new BN(0, 10);                // unknown credential
+  static CREDENTIAL_USERNAME = new BN(1, 10);
+  static CREDENTIAL_PASSWORD = new BN(2, 10);
+  static CREDENTIAL_CARD_NUMBER = new BN(3, 10);            // payment credentials
+  static CREDENTIAL_CARD_EXPIRATION_MONTH = new BN(4, 10);  
+  static CREDENTIAL_CARD_EXPIRATION_YEAR = new BN(5, 10);
+  static CREDENTIAL_CARD_SECURITY_CODE = new BN(6, 10);
+  static CREDENTIAL_ADDRESS = new BN(7, 10);
+  static CREDENTIAL_AREA_CODE = new BN(8, 10);
+  static CREDENTIAL_DATE_OF_BIRTH = new BN(9, 10);
+  static CREDENTIAL_ID = new BN(10, 10);
+
+  version: BigNumber;
+  flags: BigNumber;
+  credentialType: BigNumber;
+  credential: string;
+  recipient: string;
+  note: string;
+
+  constructor(data?: {
+    version?: BigNumber,
+    flags?: BigNumber,
+    credentialType?: BigNumber,
+    credential?: string,
+    recipient?: string,
+    note?: string,
+  }) {
+    this.version = Credential.VERSION_INVALID;
+    this.flags = new BN(0, 10);
+    this.credentialType = Credential.CREDENTIAL_UNKNOWN;
+    this.credential = "";
+    this.recipient = "";
+    this.note = "";
+
+    if (data) {
+      if (data.flags) this.flags = data.flags;
+      if (data.version) this.version = data.version;
+      if (data.credentialType) this.credentialType = data.credentialType;
+      if (data.credential) this.credential = data.credential;
+      if (data.recipient) this.recipient = data.recipient;
+      if (data.note) this.note = data.note;
+
+      this.setFlags();
+    }
+  }
+
+  getByteLength(): number {
+    let length = 0;
+
+    length += 4; // version (UInt32)
+    length += 4; // flags (UInt32)
+    length += 4; // credentialType (UInt32)
+
+    const credentialLength = this.credential.length;
+    length += varuint.encodingLength(credentialLength);
+    length += credentialLength;
+
+    const recipientLength = this.recipient.length;
+    length += varuint.encodingLength(recipientLength);
+    length += recipientLength;
+
+    if (this.hasNote()) {
+      length += varuint.encodingLength(this.note.length);
+      length += Buffer.from(this.note).length;
+    } 
+
+    return length;
+  }
+
+  toBuffer(): Buffer {
+    const writer = new BufferWriter(Buffer.alloc(this.getByteLength()));
+
+    writer.writeUInt32(this.version.toNumber());
+    writer.writeUInt32(this.flags.toNumber());
+    writer.writeUInt32(this.credentialType.toNumber());
+
+    writer.writeVarSlice(Buffer.from(this.credential));
+    writer.writeVarSlice(Buffer.from(this.recipient));
+
+    if (this.hasNote()) {
+      writer.writeVarSlice(Buffer.from(this.note));
+    }
+
+    return writer.buffer;
+  }
+
+  fromBuffer(buffer: Buffer, offset?: number): number {
+    const reader = new BufferReader(buffer, offset);
+
+    this.version = new BN(reader.readUInt32(), 10);
+    this.flags = new BN(reader.readUInt32(), 10);
+    this.credentialType = new BN(reader.readUInt32(), 10);
+
+    this.credential = Buffer.from(reader.readVarSlice()).toString();
+    this.recipient = Buffer.from(reader.readVarSlice()).toString();
+
+    if (this.hasNote()) {
+      this.note = Buffer.from(reader.readVarSlice()).toString();
+    }
+
+    return reader.offset;
+  }
+
+  hasNote(): boolean {
+    return this.flags.and(Credential.FLAG_NOTE_PRESENT).gt(new BN(0, 10));
+  }
+
+  calcFlags(): BigNumber {
+    return this.note.length > 0 ? Credential.FLAG_NOTE_PRESENT : new BN(0, 10);
+  }
+
+  setFlags() {
+    this.flags = this.calcFlags();
+  }
+
+  isValid(): boolean {
+    return this.version.gte(Credential.VERSION_FIRST) && this.version.lte(Credential.VERSION_LAST);
+  }
+
+  toJSON(): CredentialJSON {
+    const ret: CredentialJSON = {
+      version: this.version.toNumber(),
+      flags: this.flags.toNumber(),
+      credentialType: this.credentialType.toNumber(),
+      credential: this.credential,
+      recipient: this.recipient,
+      note: this.hasNote() ? this.note : null
+    };
+
+    return ret;
+  }
+
+  static fromJSON(json: CredentialJSON): Credential {
+    return new Credential({
+      version: json.version ? new BN(json.version, 10) : undefined,
+      flags: json.flags ? new BN(json.flags, 10) : undefined,
+      credentialType: json.credentialType ? new BN(json.credentialType, 10) : undefined,
+      credential: json.credential,
+      recipient: json.recipient,
+      note: json.note,
+    });
+  }
+}

--- a/src/pbaas/Credential.ts
+++ b/src/pbaas/Credential.ts
@@ -37,6 +37,7 @@ export class Credential implements SerializableEntity {
   static CREDENTIAL_AREA_CODE = new BN(8, 10);
   static CREDENTIAL_DATE_OF_BIRTH = new BN(9, 10);
   static CREDENTIAL_ID = new BN(10, 10);
+  static CREDENTIAL_PHONE_NUMBER = new BN(11, 10);
 
   version: BigNumber;
   flags: BigNumber;


### PR DESCRIPTION
The credential contains the
- **Version**: Class version
- **Flags**: Indicates if there is a note attached
- **Credential Type**: Indicates the type, including username, password or payment details
- **Credential**: The credential itself
- **Recipient**: Indicate the ID or URL that is supposed to receive the credential
- **Note** (optional): Any additional information related to the credential

This also adds an optional list of credentials to the login response decision, so that login credentials can be passed from the wallet to an application.